### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[ablazleon/jx-py-gke-3newcluster](https://github.com/ablazleon/jx-py-gke-3newcluster.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[ablazleon/jx-py-gke-3newcluster](https://github.com/ablazleon/jx-py-gke-3newcluster.git) |  | []() | 
+[ablazleon/node-jx](https://github.com/ablazleon/node-jx.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: ablazleon
-  repo: jx-py-gke-3newcluster
-  url: https://github.com/ablazleon/jx-py-gke-3newcluster.git
+  repo: node-jx
+  url: https://github.com/ablazleon/node-jx.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: ablazleon
+  repo: jx-py-gke-3newcluster
+  url: https://github.com/ablazleon/jx-py-gke-3newcluster.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/ablazleon-jx-py-gke-3newcluster-sr.yaml
+++ b/repositories/templates/ablazleon-jx-py-gke-3newcluster-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: jx-py-gke-3newcluster
+  name: ablazleon-jx-py-gke-3newcluster
+spec:
+  description: Imported application for ablazleon/jx-py-gke-3newcluster
+  httpCloneURL: https://github.com/ablazleon/jx-py-gke-3newcluster.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-py-gke-3newcluster
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/jx-py-gke-3newcluster.git

--- a/repositories/templates/ablazleon-jx-py-gke-3newcluster-sr.yaml
+++ b/repositories/templates/ablazleon-jx-py-gke-3newcluster-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: ablazleon

--- a/repositories/templates/ablazleon-node-jx-sr.yaml
+++ b/repositories/templates/ablazleon-node-jx-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: node-jx
+  name: ablazleon-node-jx
+spec:
+  description: Imported application for ablazleon/node-jx
+  httpCloneURL: https://github.com/ablazleon/node-jx.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: node-jx
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/node-jx.git

--- a/repositories/templates/ablazleon-node-jx-sr.yaml
+++ b/repositories/templates/ablazleon-node-jx-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: ablazleon


### PR DESCRIPTION
Update [ablazleon/node-jx](https://github.com/ablazleon/node-jx.git) 

Command run was `jx import node-jx-lint --git-public`
<hr />

Update [ablazleon/node-jx](https://github.com/ablazleon/node-jx.git) 

Command run was `jx create quickstart --git-public`
<hr />

Update [ablazleon/jx-py-gke-3newcluster](https://github.com/ablazleon/jx-py-gke-3newcluster.git) 

Command run was `jx import py-gke --git-public`
<hr />

Update [ablazleon/jx-py-gke-3newcluster](https://github.com/ablazleon/jx-py-gke-3newcluster.git) 

Command run was `jx create quickstart --git-public`